### PR TITLE
Feature: Add audio & vibration warning reminder before call limit

### DIFF
--- a/app/src/main/java/com/thirumalai/calllimiter/Data/PreferenceHelper.java
+++ b/app/src/main/java/com/thirumalai/calllimiter/Data/PreferenceHelper.java
@@ -22,6 +22,8 @@ public class PreferenceHelper {
     private static final String LIMIT_FOR_ALL_NUMBERS = "limit_for_all_numbers_key";
     private static final String TIME_LIMIT_FOR_ALL_NUMBERS = "time_limit_for_all_numbers_key";
     private static final String RESET_TIME_LIMIT_EACH_CALL = "reset_time_limit_each_call";
+    private static final String WARNING_REMINDER_KEY = "warning_reminder_key";
+    private static final String WARNING_REMINDER_TIME_KEY = "warning_reminder_time_key";
     private static SharedPreferences contactDataStore, lastUpdatedStore, firstTimeStore, settingsStore, readTermsAndConditionsStore;
     private static SharedPreferences.Editor contactDataEditor, lastUpdatedEditor, firstTimeEditor, settingsEditor, readTermsAndConditionsEditor;
 
@@ -138,6 +140,22 @@ public class PreferenceHelper {
 
     public static boolean getLimitForEachCallValue(){
         return settingsStore.getBoolean(RESET_TIME_LIMIT_EACH_CALL, false);
+    }
+
+    public static void updateWarningReminderEnabled(boolean enabled){
+        settingsEditor.putBoolean(WARNING_REMINDER_KEY, enabled).apply();
+    }
+
+    public static boolean getWarningReminderEnabled(){
+        return settingsStore.getBoolean(WARNING_REMINDER_KEY, true);
+    }
+
+    public static void updateWarningReminderTime(int time){
+        settingsEditor.putInt(WARNING_REMINDER_TIME_KEY, time).apply();
+    }
+
+    public static int getWarningReminderTime(){
+        return settingsStore.getInt(WARNING_REMINDER_TIME_KEY, 15);
     }
 
 //    public static Map<String, ?> setAllContactLimits(Context context) {

--- a/app/src/main/java/com/thirumalai/calllimiter/Service/CallMonitorService.java
+++ b/app/src/main/java/com/thirumalai/calllimiter/Service/CallMonitorService.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.BitmapFactory;
+import android.media.AudioManager;
+import android.media.ToneGenerator;
 import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
@@ -49,6 +51,7 @@ public class CallMonitorService extends Service {
     private PhoneStateListener phoneStateListener;
     private PhoneNumberUtil phoneNumberUtil;
     private boolean isTimerRunning = false, islimitRestForEachCallEnabled = false;
+    private boolean hasTriggeredWarning = false;
     private int elapsedTime = 1; // Time in seconds
     private static CallMonitorService instance;
     private PendingIntent pendingIntent;
@@ -196,6 +199,7 @@ public class CallMonitorService extends Service {
             return;
         }
         isTimerRunning = true;
+        hasTriggeredWarning = false;
         endCallRunnable = () -> {
             endCall();
         };
@@ -207,6 +211,7 @@ public class CallMonitorService extends Service {
         if (isTimerRunning) {
             isTimerRunning = false;
         }
+        hasTriggeredWarning = false;
         if (endCallRunnable != null) {
             handler.removeCallbacks(endCallRunnable);
             handler.removeCallbacks(updateRunnable); // Stop updating notification
@@ -223,11 +228,47 @@ public class CallMonitorService extends Service {
         public void run() {
             if (isTimerRunning) {
                 elapsedTime++;
+
+                int remainingSeconds = (callTimeLimit / 1000) - elapsedTime;
+                boolean isWarningReminderEnabled = PreferenceHelper.getWarningReminderEnabled();
+                int warningReminderTime = PreferenceHelper.getWarningReminderTime();
+
+                if (isWarningReminderEnabled && remainingSeconds == warningReminderTime && !hasTriggeredWarning) {
+                    hasTriggeredWarning = true;
+                    triggerWarningAlert();
+                }
+
                 updateTimerNotification();
                 handler.postDelayed(this, 1000); // Repeat every second
             }
         }
     };
+
+    private void triggerWarningAlert() {
+        try {
+            ToneGenerator toneGenerator = new ToneGenerator(AudioManager.STREAM_VOICE_CALL, 80);
+            toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP2, 250);
+            handler.postDelayed(toneGenerator::release, 500);
+        } catch (Exception e) {
+            Log.e("CallMonitorService", "Error playing warning tone: " + e.getMessage());
+        }
+
+        try {
+            Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+            if (vibrator != null && vibrator.hasVibrator()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    long[] timings = {0, 150, 100, 150};
+                    VibrationEffect vibrationEffect = VibrationEffect.createWaveform(timings, -1);
+                    vibrator.vibrate(vibrationEffect);
+                } else {
+                    long[] pattern = {0, 150, 100, 150};
+                    vibrator.vibrate(pattern, -1);
+                }
+            }
+        } catch (Exception e) {
+            Log.e("CallMonitorService", "Error triggering warning vibration: " + e.getMessage());
+        }
+    }
 
     private void endCall() {
         try {

--- a/app/src/main/java/com/thirumalai/calllimiter/Service/CallMonitorService.java
+++ b/app/src/main/java/com/thirumalai/calllimiter/Service/CallMonitorService.java
@@ -41,6 +41,8 @@ import org.json.JSONObject;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class CallMonitorService extends Service {
     private static final String CHANNEL_ID = "CallMonitorChannel";
@@ -53,6 +55,7 @@ public class CallMonitorService extends Service {
     private boolean isTimerRunning = false, islimitRestForEachCallEnabled = false;
     private boolean hasTriggeredWarning = false;
     private int elapsedTime = 1; // Time in seconds
+    private final ExecutorService alertExecutor = Executors.newSingleThreadExecutor();
     private static CallMonitorService instance;
     private PendingIntent pendingIntent;
     private boolean wasInCall = false;
@@ -195,11 +198,11 @@ public class CallMonitorService extends Service {
     }
 
     private void startCallTimer() {
+        hasTriggeredWarning = false;
         if (isTimerRunning) {
             return;
         }
         isTimerRunning = true;
-        hasTriggeredWarning = false;
         endCallRunnable = () -> {
             endCall();
         };
@@ -233,7 +236,7 @@ public class CallMonitorService extends Service {
                 boolean isWarningReminderEnabled = PreferenceHelper.getWarningReminderEnabled();
                 int warningReminderTime = PreferenceHelper.getWarningReminderTime();
 
-                if (isWarningReminderEnabled && remainingSeconds == warningReminderTime && !hasTriggeredWarning) {
+                if (isWarningReminderEnabled && remainingSeconds <= warningReminderTime && !hasTriggeredWarning) {
                     hasTriggeredWarning = true;
                     triggerWarningAlert();
                 }
@@ -245,29 +248,40 @@ public class CallMonitorService extends Service {
     };
 
     private void triggerWarningAlert() {
-        try {
-            ToneGenerator toneGenerator = new ToneGenerator(AudioManager.STREAM_VOICE_CALL, 80);
-            toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP2, 250);
-            handler.postDelayed(toneGenerator::release, 500);
-        } catch (Exception e) {
-            Log.e("CallMonitorService", "Error playing warning tone: " + e.getMessage());
-        }
-
-        try {
-            Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
-            if (vibrator != null && vibrator.hasVibrator()) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    long[] timings = {0, 150, 100, 150};
-                    VibrationEffect vibrationEffect = VibrationEffect.createWaveform(timings, -1);
-                    vibrator.vibrate(vibrationEffect);
-                } else {
-                    long[] pattern = {0, 150, 100, 150};
-                    vibrator.vibrate(pattern, -1);
+        alertExecutor.execute(() -> {
+            ToneGenerator toneGenerator = null;
+            try {
+                toneGenerator = new ToneGenerator(AudioManager.STREAM_VOICE_CALL, 80);
+                if (toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP2, 250)) {
+                    Thread.sleep(300);
+                }
+            } catch (Exception e) {
+                Log.e("CallMonitorService", "Error playing warning tone: " + e.getMessage());
+            } finally {
+                if (toneGenerator != null) {
+                    try {
+                        toneGenerator.release();
+                    } catch (Exception e) {
+                        Log.e("CallMonitorService", "Error releasing ToneGenerator: " + e.getMessage());
+                    }
                 }
             }
-        } catch (Exception e) {
-            Log.e("CallMonitorService", "Error triggering warning vibration: " + e.getMessage());
-        }
+
+            try {
+                Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+                if (vibrator != null && vibrator.hasVibrator()) {
+                    long[] timings = {0, 150, 100, 150};
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        VibrationEffect vibrationEffect = VibrationEffect.createWaveform(timings, -1);
+                        vibrator.vibrate(vibrationEffect);
+                    } else {
+                        vibrator.vibrate(timings, -1);
+                    }
+                }
+            } catch (Exception e) {
+                Log.e("CallMonitorService", "Error triggering warning vibration: " + e.getMessage());
+            }
+        });
     }
 
     private void endCall() {
@@ -367,6 +381,7 @@ public class CallMonitorService extends Service {
     public void onDestroy() {
         super.onDestroy();
         instance = null;
+        alertExecutor.shutdown();
 
         if (telephonyManager != null && phoneStateListener != null) {
             telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_NONE);

--- a/app/src/main/java/com/thirumalai/calllimiter/UI/Settings.java
+++ b/app/src/main/java/com/thirumalai/calllimiter/UI/Settings.java
@@ -32,13 +32,14 @@ import java.util.Map;
 import java.util.Objects;
 
 public class Settings extends AppCompatActivity {
-    private LinearLayout layoutTheme, githubIssues, permissions, about, timeLimitForAllNumbers;
-    private TextView selectedThemeText, bufferValueText, timeLimit;
+    private LinearLayout layoutTheme, githubIssues, permissions, about, timeLimitForAllNumbers, warningReminderTimeLayout;
+    private TextView selectedThemeText, bufferValueText, timeLimit, warningReminderTimeText;
     private ImageView backBtn;
-    private SeekBar bufferBar;
-    private MaterialSwitch switchBtn, callStartBufferSwitchBtn, limitResetForEachCallSwitchBtn;
-    private boolean isChecked = false, isCallStartBufferEnabled = true, islimitRestForEachCallEnabled = false;
+    private SeekBar bufferBar, warningReminderBar;
+    private MaterialSwitch switchBtn, callStartBufferSwitchBtn, limitResetForEachCallSwitchBtn, warningReminderSwitchBtn;
+    private boolean isChecked = false, isCallStartBufferEnabled = true, islimitRestForEachCallEnabled = false, isWarningReminderEnabled = true;
     private final int[] BUFFER_VALUES = {10, 20, 30, 60, 120, 180, 240, 300};
+    private final int[] WARNING_REMINDER_VALUES = {5, 10, 15, 20, 30, 45, 60, 120};
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -64,10 +65,16 @@ public class Settings extends AppCompatActivity {
         timeLimit = findViewById(R.id.time_limit_all_numbers_text);
         callStartBufferSwitchBtn = findViewById(R.id.call_start_buffer_time);
         limitResetForEachCallSwitchBtn = findViewById(R.id.limit_reset_each_call);
+        warningReminderSwitchBtn = findViewById(R.id.warning_reminder_switch);
+        warningReminderTimeLayout = findViewById(R.id.warning_reminder_time_layout);
+        warningReminderTimeText = findViewById(R.id.warning_reminder_time_text);
+        warningReminderBar = findViewById(R.id.warning_reminder_time_seek_bar);
 
         isChecked = PreferenceHelper.getLimitForAllNumbersEnabled();
         isCallStartBufferEnabled = PreferenceHelper.getCallStartBufferValue();
         islimitRestForEachCallEnabled = PreferenceHelper.getLimitForEachCallValue();
+        isWarningReminderEnabled = PreferenceHelper.getWarningReminderEnabled();
+        int warningReminderTime = PreferenceHelper.getWarningReminderTime();
         int timeLimit1 = PreferenceHelper.getTimeLimitForAllNumbers();
 
         int hours = timeLimit1 / 3600;
@@ -241,6 +248,44 @@ public class Settings extends AppCompatActivity {
                         e.printStackTrace();
                     }
                 }
+            }
+        });
+
+        warningReminderSwitchBtn.setChecked(isWarningReminderEnabled);
+        warningReminderTimeLayout.setVisibility(isWarningReminderEnabled ? View.VISIBLE : View.GONE);
+
+        warningReminderBar.setMax(WARNING_REMINDER_VALUES.length - 1);
+        int reminderIndex = 2;
+        for(int i = 0; i < WARNING_REMINDER_VALUES.length; i++){
+            if(WARNING_REMINDER_VALUES[i] == warningReminderTime){
+                reminderIndex = i;
+                break;
+            }
+        }
+        warningReminderBar.setProgress(reminderIndex);
+        warningReminderTimeText.setText(formatBufferTime(warningReminderTime));
+
+        warningReminderSwitchBtn.setOnCheckedChangeListener((compoundButton, enabled) -> {
+            PreferenceHelper.updateWarningReminderEnabled(enabled);
+            warningReminderTimeLayout.setVisibility(enabled ? View.VISIBLE : View.GONE);
+        });
+
+        warningReminderBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                int selectedValue = WARNING_REMINDER_VALUES[progress];
+                warningReminderTimeText.setText(formatBufferTime(selectedValue));
+                PreferenceHelper.updateWarningReminderTime(selectedValue);
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+
             }
         });
     }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -269,6 +269,69 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_weight="0.8"
+                    android:padding="8dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_limit_warning_reminder"
+                        android:textSize="16sp"/>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/call_limit_warning_reminder_desc"
+                        android:textColor="#B8B8B8"
+                        android:textSize="12sp" />
+                </LinearLayout>
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/warning_reminder_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:layout_weight="0.2"
+                    android:padding="8dp"/>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/warning_reminder_time_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/warning_reminder_time_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp"
+                    android:text="@string/_15_s"
+                    android:paddingStart="10dp"
+                    android:paddingEnd="0dp"
+                    android:paddingVertical="8dp"
+                    android:layout_gravity="center"
+                    android:layout_weight="0.05"/>
+
+                <SeekBar
+                    android:id="@+id/warning_reminder_time_seek_bar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:paddingVertical="8dp"
+                    android:layout_weight="0.95"/>
+
+            </LinearLayout>
+
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -32,7 +32,17 @@
 
     </LinearLayout>
 
-    <com.google.android.material.card.MaterialCardView
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="10dp"
@@ -272,13 +282,14 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
 
                 <LinearLayout
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:layout_weight="0.8"
+                    android:layout_weight="1"
                     android:padding="8dp">
 
                     <com.google.android.material.textview.MaterialTextView
@@ -298,9 +309,7 @@
                 <com.google.android.material.materialswitch.MaterialSwitch
                     android:id="@+id/warning_reminder_switch"
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:layout_weight="0.2"
+                    android:layout_height="wrap_content"
                     android:padding="8dp"/>
 
             </LinearLayout>
@@ -309,26 +318,40 @@
                 android:id="@+id/warning_reminder_time_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="vertical">
 
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/warning_reminder_time_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:textSize="14sp"
-                    android:text="@string/_15_s"
-                    android:paddingStart="10dp"
-                    android:paddingEnd="0dp"
-                    android:paddingVertical="8dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="0.05"/>
+                    android:text="@string/reminder_time"
+                    android:textSize="16sp"
+                    android:padding="8dp"/>
 
-                <SeekBar
-                    android:id="@+id/warning_reminder_time_seek_bar"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:paddingVertical="8dp"
-                    android:layout_weight="0.95"/>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/warning_reminder_time_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp"
+                        android:text="@string/_15_s"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="0dp"
+                        android:paddingVertical="8dp"
+                        android:layout_gravity="center"
+                        android:layout_weight="0.05"/>
+
+                    <SeekBar
+                        android:id="@+id/warning_reminder_time_seek_bar"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:paddingVertical="8dp"
+                        android:layout_weight="0.95"/>
+
+                </LinearLayout>
 
             </LinearLayout>
 
@@ -451,6 +474,9 @@
 
         </LinearLayout>
 
-    </com.google.android.material.card.MaterialCardView>
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,4 +66,10 @@
     <string name="bitcoin">Bitcoin</string>
     <string name="bitcoin_address">bc1q26ag0k77ez63pd0zu492vj7dncfqmknkk7sjfh</string>
     <string name="reset_limit_on_each_call">Reset limit on each call</string>
+    <string name="call_limit_warning_reminder">Call Limit Warning Reminder</string>
+    <string name="call_limit_warning_reminder_desc">Plays a tone and vibrates before the call limit is reached</string>
+    <string name="reminder_time">Reminder Time</string>
+    <string name="_15_s">15 s</string>
+    <string name="_30_s">30 s</string>
+    <string name="_60_s">60 s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,4 @@
     <string name="call_limit_warning_reminder_desc">Plays a tone and vibrates before the call limit is reached</string>
     <string name="reminder_time">Reminder Time</string>
     <string name="_15_s">15 s</string>
-    <string name="_30_s">30 s</string>
-    <string name="_60_s">60 s</string>
 </resources>


### PR DESCRIPTION
## Description
This PR introduces an audio and haptic warning reminder before reaching the call duration limit, preventing unexpected call cut-offs.

## Features
- **In-Call Audio & Haptic Alert**: Plays an in-call supervisor tone (\ToneGenerator.TONE_PROP_BEEP2\ on \AudioManager.STREAM_VOICE_CALL\) and a double vibration pulse when the remaining call duration reaches the chosen threshold.
- **Customizable Settings**:
  - Toggle to enable/disable the reminder.
  - Horizontal \SeekBar\ slider (identical to *Emergency Buffer Time*) allowing users to set their preferred reminder threshold (5s, 10s, 15s, 20s, 30s, 45s, 60s, 120s).
- **Persistent Preferences**: Added state management in \PreferenceHelper\.
- **Privacy & Permissions**: Works completely offline and requires no additional permissions.